### PR TITLE
Fix infinity loop issue when resolving multiple roles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME := aws-cli-oidc
-VERSION := v0.2.0
+VERSION := v0.3.0
 REVISION := $(shell git rev-parse --short HEAD)
 
 SRCS    := $(shell find . -type f -name '*.go')


### PR DESCRIPTION
Currently, `saml2aws` is used for selecting a role if the user has multiple roles. But the selecting logic depends on the selecting role screen on AWS. It might cause this inifinity loop problem. It's not stable to parsing the screen HTML. So I decided to change the logic for selecting a role.